### PR TITLE
Initial Code from Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# wpm-user-sync
-WPM User Sync WordPress plugin
+# WPM User Sync WordPress Plugin
+
+Hello and Welcome! 'WPM User Sync' (which actually means "WordPress Multi-Site User Synchronization") is a plugin that allow you to configure & automate users sync between wordpress sites when you are using a multi-site setup. You will find options at network & sites level, to take aboslute control with what happen when: a new user is created, a new site is created, and when we change a role for an existing user.
+
+## How can I contribute?
+
+Just fork this repo, improve the code & send a PR to review :-)
+
+## Installation
+
+The normal plugin install process applies, that is search for 'Hola Simpsons' from your plugin screen or via the manual method:
+
+1. Upload the 'Hola Simpsons' folder into your '/wp-content/plugins/' directory.
+1. Activate the plugin through the 'Plugins' menu in WordPress.
+
+That's it! 'WPM User Sync' will appear in your dashboard at Network & Site level
+
+## Frequently Asked Questions
+
+### What exactly does this plugin do?
+
+WPM User Sync is a plugin that enable the user synchronization in your Wordpress Multisite, that is a type of WordPress installation that allows you to create and manage a network of multiple websites from a single WordPress dashboard. Key concepts:
+
+* WPM User sync is a plugin, not a core feature of WordPress. It was built by external developers to WordPress. However, it goes through a detailed testing process to ensure smooth operation as it interacts with core aspects of the CMS.
+* In out-of-the-box WordPress multisite setup, when you create a new user, it never sync to other sites in your network. Also, when you create a new site in your network, no users are synced to this new site. This means that you must manually register or associate users to your site, or your new site with your users. This is a tedious and manual process.
+* This plugin bring you the possibility tu automate all this scenarios: a) when you create a new user, this user can be synced to all existing sites in your network; b) when you create a new site, all users can be automatic synced to it; c) when we change an user role in one site, you can configure to replicate this change to all sites in your network; d) if you do not want automation, with this plugin you can do all previous things in manual mode :-).
+* Last but not least, when we talk about 'user synchronization', we never duplicate user data. The user is only one, and the same identity is the one that is added to the sites in a reference model. If you are using "SUBDOMAIN_INSTALL" option (that is, each site on your network will be a subdomain) and you want "single-sign on experience", you should configure some cookies aspects in your WP-CONFIG. Check plugin's website help for more information.
+
+### What is a trigger? Which ones exist here?
+
+In WPM User Sync you will can configure some triggers to automate user sync. A trigger is procedural code that is automatically executed in response to certain events, and in the particular case of WPM User Sync & WordPress, to one of the following events:
+
+* New user creation: when an user register in your site, or an admin create a new one.
+* New site creation: when an admin or authorized user create a new site in your network.
+* User role edited in one site: when you edit a user role in one of your network sites.
+
+Its very important to remember that you can configure all these 3 triggers from network level options.
+
+### What kind of options do I have at the network level?
+
+At network level you can configure the 3 triggers that we descripted in the past:
+
+* New Site Automatic Sync: When a new site is created in the network, all users in the database will be added to this new site with default site role. If no default role is configured, "subscriber" role will be added.
+* New User Automatic Sync: When a new user is created in the network, will be added to all sites in the database with each default site role. If no default role is configured, "subscriber" role will be added.
+* Set User Role Automatic Sync: When an user role change is detected in any site (for example change an user to administrator of an specific site) this change will be replicated to all other sites (in the other sites will be administrator, too).
+
+Also, you can execute the following actions:
+
+* Sync from scratch: Sync all sites with all users. Each site will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+* Sync specific site: All selected sites will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+
+### What can configure an administrator at site level?
+
+At site level you can not configure any option. But you can execute the following action:
+
+* Sync from scratch: Add all network users in your site with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+
+### Can I avoid automatic actions and only act with manual actions?
+
+Yes! You can. Disable all triggers at network level & you will allow to execute only manual actions.
+
+### Does this plugin host information in the local WordPress database?
+
+Yes. This plugin host information in "sitemeta" table to remember network sync options.
+
+### Does this plugin connect to any external web service?
+
+Nope.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Just fork this repo, improve the code & send a PR to review :-)
 
 ## Installation
 
-The normal plugin install process applies, that is search for 'Hola Simpsons' from your plugin screen or via the manual method:
+The normal plugin install process applies, that is search for 'WPM User Sync' from your plugin screen or via the manual method:
 
-1. Upload the 'Hola Simpsons' folder into your '/wp-content/plugins/' directory.
+1. Upload the 'WPM User Sync' folder into your '/wp-content/plugins/' directory.
 1. Activate the plugin through the 'Plugins' menu in WordPress.
 
 That's it! 'WPM User Sync' will appear in your dashboard at Network & Site level

--- a/src/core/wpmus-functions.php
+++ b/src/core/wpmus-functions.php
@@ -1,0 +1,247 @@
+<?php
+
+
+    function wpmus_plugin_activate() {
+
+        //
+
+    }
+
+    function wpmus_init() {
+
+		add_action ( 'admin_enqueue_scripts', 'wpmus_add_css' );
+
+    }
+
+    function wpmus_add_css() {
+
+        wp_enqueue_style ( 'wpmus_styles', plugins_url('css/wpmus_styles.css', dirname(__FILE__)), '', '1.0' );
+        // wp_enqueue_style ( 'wpmus_styles', plugins_url('/wpmus_styles.css', __FILE__), '', '1.0' );
+
+    }
+
+    function wpmus_check_requirements() {
+        global $wp_version;
+        global $pluginBaseName;
+        global $pluginData;
+        global $pluginRequireWp;
+        global $wpdb;
+    
+        if ( version_compare( $wp_version, $pluginRequireWp, "<" ) ) {
+            if( is_plugin_active($pluginBaseName) ) {
+                deactivate_plugins( $pluginBaseName );
+                wp_die( "<strong>".$pluginData['Name']."</strong> requires <strong>WordPress ".$pluginRequireWp."</strong> or higher, and has been deactivated! Please upgrade WordPress and try again.<br /><br />Back to the WordPress <a href='".get_admin_url(null, 'plugins.php')."'>Plugins page</a>." );
+            }
+        }
+
+        if ( ! is_multisite() ) {
+            if( is_plugin_active($pluginBaseName) ) {
+                deactivate_plugins( $pluginBaseName );
+                wp_die( "<strong>".$pluginData['Name']."</strong> requires <strong>WordPress Multisite</strong> installation, and has been deactivated! Please configure WordPress for multisite porpuses and try again.<br /><br />Back to the WordPress <a href='".get_admin_url(null, 'plugins.php')."'>Plugins page</a>." );
+            }
+		}
+
+    }
+
+    function wpmus_sync_newsite( $blog_id ) {
+        global $wpmus_newSiteSync;
+        global $wpdb;
+
+        if ($wpmus_newSiteSync == 'yes') {
+
+            // $users = get_users( array( 'blog_id' => get_current_blog_id(), 'fields' => 'all_with_meta' ) );
+            $args = array( 'blog_id' => 0 );
+            $users = get_users( $args );
+
+            remove_action( 'wpmu_new_blog', 'wpmus_sync_newsite', 10, 3 );
+            foreach ( $users as $user ) {
+                
+                if ( ! is_user_member_of_blog( $user->ID, $blog_id ) ) {
+
+                    if ( is_array( $user->roles ) && $user->roles ) {
+                        add_user_to_blog( $blog_id, $user->ID, $user->roles[0] );
+                    }
+                    else {
+                        add_user_to_blog( $blog_id, $user->ID, get_blog_option( $blog_id, 'default_role', 'subscriber' ) );
+
+                    }
+                }
+
+            }
+            add_action( 'wpmu_new_blog', 'wpmus_sync_newsite', 10, 3 );
+
+        }
+
+    }
+
+    function wpmus_sync_newuser( $user_id ) {
+        global $wpmus_newUserSync;
+        global $wpdb;
+	
+        if ($wpmus_newUserSync == 'yes') {
+
+            // Query all blogs from multi-site install
+            $blogids = $wpdb->get_col( "SELECT blog_id FROM {$wpdb->base_prefix}blogs" );
+            
+
+                
+            remove_action( 'wpmu_new_user', 'wpmus_sync_newuser', 10, 3 );
+            foreach ( $blogids as $blogid ) {
+                add_user_to_blog( $blogid, $user_id, get_blog_option( $blogid, 'default_role', 'subscriber' ) );
+            }
+            
+            add_action( 'set_user_role', 'wpmus_sync_newuser', 10, 3 );
+
+
+            
+        }
+    }
+    
+    function wpmus_sync_newrole( $user_id, $role ) {
+        global $wpmus_setUserRoleSync;
+        global $wpdb;
+	
+        if ($wpmus_setUserRoleSync == 'yes') {
+	
+            // Query all blogs from multi-site install
+            $blogids = $wpdb->get_col( "SELECT blog_id FROM {$wpdb->base_prefix}blogs" );
+        
+            remove_action( 'set_user_role', 'wpmus_sync_newrole', 10, 2 );
+            foreach ( $blogids as $blogid ) {
+
+                if ( is_user_member_of_blog( $user_id, $blogid ) ) {
+                    add_user_to_blog( $blogid, $user_id, $role );
+                }
+
+            }
+            add_action( 'set_user_role', 'wpmus_sync_newrole', 10, 2 );
+
+        }
+    }
+
+    function wpmus_sync_NetworkFromScratch() {
+
+        check_admin_referer( 'wpmus-validate' ); // Nonce security check
+
+        global $wpdb;
+        $blogids = $wpdb->get_col( "SELECT blog_id FROM {$wpdb->base_prefix}blogs" );
+        $args = array( 'blog_id' => 0 );
+        $users = get_users( $args );
+            
+        foreach ( $users as $user ) {
+            foreach ( $blogids as $blogid ) {
+                if ( ! is_user_member_of_blog( $user->ID, $blogid ) ) {
+                    add_user_to_blog( $blogid, $user->ID, get_blog_option( $blogid, 'default_role', 'subscriber' ) );
+                }
+            }
+        }
+
+        wp_redirect( add_query_arg( array(
+            'page' => 'wpmus-networksyncactions',
+            'synced' => true ), network_admin_url('admin.php')
+        ));
+     
+        exit;
+    }
+
+    function wpmus_sync_NetworkSiteFromScratch() {
+
+        check_admin_referer( 'wpmus-validate' ); // Nonce security check
+
+        global $wpdb;
+
+        $args = array( 'blog_id' => 0 );
+        $users = get_users( $args );
+
+        $listSites = sanitize_text_field($_POST['listSites']);
+        
+        if(! empty($listSites)) {
+
+
+            foreach ( $listSites as $blogid) {
+
+                foreach ( $users as $user ) {
+
+                    if ( ! is_user_member_of_blog( $user->ID, $blogid ) ) {
+                        add_user_to_blog( $blogid, $user->ID, get_blog_option( $blogid, 'default_role', 'subscriber' ) );
+                    }
+
+                }
+
+            }
+
+            wp_redirect( add_query_arg( array(
+                'page' => 'wpmus-networksyncactions',
+                'synced' => true ), network_admin_url('admin.php')
+            ));
+
+        }else{
+            wp_redirect( add_query_arg( array(
+                'page' => 'wpmus-networksyncactions',
+                'nosynced' => true ), network_admin_url('admin.php')
+            ));
+        }
+
+        exit;
+    }
+
+    function wpmus_sync_SiteSiteFromScratch() {
+
+        check_admin_referer( 'wpmus-validate' ); // Nonce security check
+
+        global $wpdb;
+
+        $args = array( 'blog_id' => 0 );
+        $users = get_users( $args );
+
+        $blogid = sanitize_text_field($_POST['wpmus_blogid']);
+            
+        foreach ( $users as $user ) {
+
+            if ( ! is_user_member_of_blog( $user->ID, $blogid ) ) {
+                add_user_to_blog( $blogid, $user->ID, get_blog_option( $blogid, 'default_role', 'subscriber' ) );
+            }
+
+        }
+
+        wp_redirect( add_query_arg( array(
+            'page' => 'wpmus-sitesyncactions',
+            'synced' => true ), admin_url('admin.php')
+        ));
+
+        exit;
+    }
+    
+    function wpmus_save_GlobalConfig(){
+ 
+        check_admin_referer( 'wpmus-validate' ); // Nonce security check
+     
+        update_site_option( 'wpmus_newSiteSync', sanitize_text_field($_POST['wpmus_newSiteSync']) );
+        update_site_option( 'wpmus_newUserSync', sanitize_text_field($_POST['wpmus_newUserSync']) );
+        update_site_option( 'wpmus_setUserRoleSync', sanitize_text_field($_POST['wpmus_setUserRoleSync']) );
+     
+        wp_redirect( add_query_arg( array(
+            'page' => 'wpmus-networksyncoptions',
+            'updated' => true ), network_admin_url('admin.php')
+        ));
+     
+        exit;
+     
+    }
+    
+    
+    function wpmus_notice_updated(){
+     
+        if( isset($_GET['page']) && isset( $_GET['updated'] )  ) {
+            echo '<div id="message" class="updated notice is-dismissible"><p>Settings updated. You\'re the best!</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></div>';
+        }
+
+        if( isset($_GET['page']) && isset( $_GET['synced'] )  ) {
+            echo '<div id="message" class="updated notice is-dismissible"><p>Sync done. You\'re a champion!</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></div>';
+        }
+
+        if( isset($_GET['page']) && isset( $_GET['nosynced'] )  ) {
+            echo '<div id="message" class="notice notice-warning is-dismissible"><p>Sync did not happen. You\'re must select at least one site!</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></div>';
+        }
+     
+    }

--- a/src/core/wpmus-variables.php
+++ b/src/core/wpmus-variables.php
@@ -1,0 +1,13 @@
+<?php
+
+$pluginRoute = plugin_basename( 'wpm-user-sync/wpm-user-sync.php' );
+$pluginBaseName = plugin_basename( $pluginRoute );
+if (!function_exists('get_plugin_data')) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+$pluginData = get_plugin_data(realpath(dirname(__FILE__) . '/..') . '/wpm-user-sync.php');
+$pluginRequireWp = $pluginData["RequiresWP"];
+
+$wpmus_newSiteSync = get_site_option( 'wpmus_newSiteSync');
+$wpmus_newUserSync = get_site_option( 'wpmus_newUserSync');
+$wpmus_setUserRoleSync = get_site_option( 'wpmus_setUserRoleSync');

--- a/src/css/wpmus_styles.css
+++ b/src/css/wpmus_styles.css
@@ -1,0 +1,16 @@
+.cuadrado {
+    background-color: #5975b1;
+    padding: 40px 10px;
+    text-align: center;
+    color: white;
+    width: 125px;
+    text-decoration: none;
+    display: inline-block;
+    margin: 5px;
+  }
+  
+  .cuadrado:hover {
+    background-color: #4061a8;
+    color: white;
+    text-decoration: none;
+  }

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,2 @@
+<?php
+# Silence is golden.

--- a/src/network-admin/wpmus-network-common.php
+++ b/src/network-admin/wpmus-network-common.php
@@ -1,0 +1,19 @@
+<?php
+
+// SECTIONS
+
+
+
+// HEADER
+
+    function wpmus_generic_header() {
+		?>
+
+		<div class="wrap">
+			<h2>WPM User Sync</h2>
+			<p>Welcome to the <strong>best free user synchronization solution</strong> for WordPress Multisite.</p>
+		</div>
+				
+		<?php
+    }
+

--- a/src/network-admin/wpmus-network-home.php
+++ b/src/network-admin/wpmus-network-home.php
@@ -1,0 +1,132 @@
+<?php
+
+function wpmus_network_home_content() {
+    
+    global $sd_active_tab;
+
+    if (isset($_GET['tab'])) {
+        $sd_active_tab = sanitize_text_field($_GET['tab']);
+        
+    }else{
+        $sd_active_tab = 'welcome';
+
+    }
+    
+    ?>
+
+    <h2 class="nav-tab-wrapper">
+    <?php
+        do_action( 'wpmus_network_home_tabs' );
+    ?>
+    </h2>
+    <?php
+        do_action( 'wpmus_network_home_contents' );
+    
+}
+
+function wpmus_network_home_welcome_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'welcome' || '' ? 'nav-tab-active' : ''; ?>" href="<?php echo network_admin_url( 'admin.php?page=wpmus-networkhome&tab=welcome' ); ?>"><?php _e( 'Welcome', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_network_home_concepts_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'concepts' ? 'nav-tab-active' : ''; ?>" href="<?php echo network_admin_url( 'admin.php?page=wpmus-networkhome&tab=concepts' ); ?>"><?php _e( 'Concepts', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_network_home_about_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'about' ? 'nav-tab-active' : ''; ?>" href="<?php echo network_admin_url( 'admin.php?page=wpmus-networkhome&tab=about' ); ?>"><?php _e( 'About', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_network_home_welcome_content() {
+    global $sd_active_tab;
+    if ( '' || 'welcome' != $sd_active_tab )
+        return;
+    ?>
+
+    <h3><?php _e( 'Welcome to Network "WPM User Sync" Plugin', 'sd' ); ?></h3>
+    <p>Thank you for choosing WPM User Sync (which actually means "WordPress Multi-Site User Synchronization"). Thank you for choosing WPM User Sync (which actually means "WordPress Multi-Site User Synchronization"). Follow the next steps to getting start synchronizing:</p>
+
+    <a href="<?php echo network_admin_url( 'admin.php?page=wpmus-networkhome&tab=concepts' ); ?>" class="cuadrado">1. Review basic concepts</a>
+    <a href="<?php echo network_admin_url( 'admin.php?page=wpmus-networksyncactions' ); ?>" class="cuadrado">2. Complete the initial Users Sync</a>
+    <a href="<?php echo network_admin_url( 'admin.php?page=wpmus-networksyncoptions' ); ?>" class="cuadrado">3. Check all WPM User Sync options</a>
+    <a href="<?php echo network_admin_url( 'admin.php?page=wpmus-networkhome&tab=about' ); ?>" class="cuadrado">4. Meet the Authors & Support Us</a>
+
+    <p>Do you want online help? Check our <a href="https://pablodiloreto.com/wpm-user-sync/">site</a>.</p>
+    
+    <?php
+    
+}
+
+function wpmus_network_home_concepts_content() {
+    global $sd_active_tab;
+    if ( 'concepts' != $sd_active_tab )
+        return;
+    ?>
+
+    <h3><?php _e( 'User Sync Concepts', 'sd' ); ?></h3>
+    <p>WPM User Sync has some simple but important concepts. Knowning all them will help you to get a better experience with the tool.</p>
+
+    <h4>What exactly does this plugin do?</h4>
+    <p>WPM User Sync is a plugin that enable the user synchronization in your Wordpress Multisite, that is a type of WordPress installation that allows you to create and manage a network of multiple websites from a single WordPress dashboard.</p>
+    <p>Key concepts:</p>
+    <ul>
+        <li>- WPM User sync is a plugin, not a core feature of WordPress. It was built by external developers to WordPress. However, it goes through a detailed testing process to ensure smooth operation as it interacts with core aspects of the CMS.</li>
+        <li>- In out-of-the-box WordPress multisite setup, when you create a new user, it never sync to other sites in your network. Also, when you create a new site in your network, no users are synced to this new site. This means that you must manually register or associate users to your site, or your new site with your users. This is a tedious and manual process.</li>
+        <li>- This plugin bring you the possibility tu automate all this scenarios: a) when you create a new user, this user can be synced to all existing sites in your network; b) when you create a new site, all users can be automatic synced to it; c) when we change an user role in one site, you can configure to replicate this change to all sites in your network; d) if you do not want automation, with this plugin you can do all previous things in manual mode :-).</li>
+        <li>- Last but not least, when we talk about 'user synchronization', we never duplicate user data. The user is only one, and the same identity is the one that is added to the sites in a reference model. If you are using "SUBDOMAIN_INSTALL" option (that is, each site on your network will be a subdomain) and you want "single-sign on experience", you should configure some cookies aspects in your WP-CONFIG. Check plugin's website help for more information.</li>
+    </ul>
+
+    <h4>What is a trigger? Which ones exist here?</h4>
+    <p>In WPM User Sync you will can configure some triggers to automate user sync. A trigger is procedural code that is automatically executed in response to certain events, and in the particular case of WPM User Sync & WordPress, to one of the following events:</p>
+    <ul>
+        <li>- <strong>New user creation</strong>: when an user register in your site, or an admin create a new one.</li>
+        <li>- <strong>New site creation</strong>: when an admin or authorized user create a new site in your network.</li>
+        <li>- <strong>User role edited in one site</strong>: when you edit a user role in one of your network sites.</li>
+    </ul>
+    <p>Its very important to remember that you can configure all these 3 triggers from network level options.</p>
+
+    <h4>What kind of options do I have at the network level?</h4>
+    <p>At network level you can configure the 3 triggers that we descripted in the past:</p>
+    <ul>
+        <li>- <strong>New Site Automatic Sync</strong>: When a new site is created in the network, all users in the database will be added to this new site with default site role. If no default role is configured, "subscriber" role will be added.</li>
+        <li>- <strong>New User Automatic Sync</strong>: When a new user is created in the network, will be added to all sites in the database with each default site role. If no default role is configured, "subscriber" role will be added.</li>
+        <li>- <strong>Set User Role Automatic Sync</strong>: When an user role change is detected in any site (for example change an user to administrator of an specific site) this change will be replicated to all other sites (in the other sites will be administrator, too).</li>
+    </ul>
+    <p>Also, you can execute the following actions:</p>
+    <ul>
+        <li>- <strong>Sync from scratch</strong>: Sync all sites with all users. Each site will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</li>
+        <li>- <strong>Sync specific site</strong>: All selected sites will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</li>
+    </ul>
+
+    <h4>What can configure an administrator at site level?</h4>
+    <p>At site level you can not configure any option. But you can execute the following action:</p>
+    <ul>
+        <li>- <strong>Sync from scratch</strong>: Add all network users in your site with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</li>
+    </ul>
+
+    <h4>Can I avoid automatic actions and only act with manual actions?</h4>
+    <p>Yes! You can. Disable all triggers at network level & you will allow to execute only manual actions.</p>
+
+    <?php
+}
+
+function wpmus_network_home_about_content() {
+global $sd_active_tab;
+if ( 'about' != $sd_active_tab )
+    return;
+?>
+
+<h3><?php _e( 'About WPM User Sync Plugin', 'sd' ); ?></h3>
+<p>This plugin was developer by <strong>Pablo Ariel Di Loreto</strong>:</p>
+<ul>
+    <li>- <a href="https://www.linkedin.com/in/pablodiloreto/" target="_blank">LinkedIn Contact</a>.</li>
+    <li>- <a href="https://pablodiloreto.com/" target="_blank">Personal Blog</a>.</li>
+    <li>- <a href="https://pablodiloreto.com/wpm-user-sync/" target="_blank">Plugin Homepage</a>.</li>
+</ul>
+<?php
+}

--- a/src/network-admin/wpmus-network-sections.php
+++ b/src/network-admin/wpmus-network-sections.php
@@ -1,0 +1,59 @@
+<?php
+
+
+// class wpmus {
+
+	function wpmus_networkmenu_items() {
+ 
+		add_menu_page(
+			'WPM User Sync', // page_title
+			'WPM User Sync', // menu_title
+			'manage_options', // capability
+			'wpmus-networkhome', // menu_slug
+			'wpmus_networkhome', // Callback function which displays the page
+			'dashicons-admin-generic', // Icon
+			100 // Position of the menu item in the menu.
+		);
+
+		add_submenu_page(
+			'wpmus-networkhome', // Parent element
+			'Network Sync Options', // Text in browser title bar
+			'Network Sync Options', // Text to be displayed in the menu.
+			'manage_options', // Capability
+			'wpmus-networksyncoptions', // Page slug, will be displayed in URL
+			'wpmus_networksyncoptions' // Callback function which displays the page
+		);
+
+		add_submenu_page(
+			'wpmus-networkhome', // Parent element
+			'Network Sync Actions', // Text in browser title bar
+			'Network Sync Actions', // Text to be displayed in the menu.
+			'manage_options', // Capability
+			'wpmus-networksyncactions', // Page slug, will be displayed in URL
+			'wpmus_networksyncactions' // Callback function which displays the page
+		);
+ 
+	}
+
+	function wpmus_networkhome() {
+    
+		echo wpmus_generic_header();
+		echo wpmus_network_home_content();
+	  
+	}
+
+	function wpmus_networksyncoptions() {
+	
+		echo wpmus_generic_header();
+		echo wpmus_network_syncoptions_settings();
+
+	}
+
+	function wpmus_networksyncactions() {
+	
+		echo wpmus_generic_header();
+		echo wpmus_network_syncactions_options();
+
+	}
+
+    

--- a/src/network-admin/wpmus-network-syncactions.php
+++ b/src/network-admin/wpmus-network-syncactions.php
@@ -1,0 +1,46 @@
+<?php
+
+function wpmus_network_syncactions_options() {
+    global $wpdb;
+    $sites = get_sites();
+
+    echo '<div class="wrap">
+    <h3>Network Sync Actions</h3>
+    <p>These actions let you sync users & sites with several options.</p>';
+        wp_nonce_field( 'wpmus-validate' );
+        echo '
+        <table class="form-table">
+            <tr>
+                <th scope="row">Sync from scratch</th>
+                <td>
+                    <form method="post" action="edit.php?action=wpmusSyncNetworkFromScratch">';
+                    wp_nonce_field( 'wpmus-validate' );
+                    echo '
+                        <input id="test-settings" type="submit" value="Sync from scratch" class="button" >
+                    </form>
+                    <p class="description">Sync all sites with all users. Each site will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</p>
+                </td>
+            </tr>
+
+            <tr>
+            <th scope="row">Sync specific site</th>
+            <td>
+                <p>Please, select the site that you want sync users:</p>
+                <br />
+                <form method="post" action="edit.php?action=wpmusSyncNetworkSiteFromScratch">';
+                wp_nonce_field( 'wpmus-validate' );
+
+                    foreach ( $sites as $site ) {
+                        echo '<input type="checkbox" name="listSites[]" value='. $site->blog_id .' />'. $site->domain, $site->path .' <br />';
+                    }
+                    echo '
+                    <input id="network" type="hidden" value="yes">
+                    <br />
+                    <input id="test-settings" type="submit" value="Sync selected sites" class="button" >
+                </form>
+                <p class="description">All selected sites will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</p>
+            </td>
+        </tr>
+        </table>';
+
+}

--- a/src/network-admin/wpmus-network-syncoptions.php
+++ b/src/network-admin/wpmus-network-syncoptions.php
@@ -1,0 +1,41 @@
+<?php
+
+function wpmus_network_syncoptions_settings() {
+    global $wpmus_newSiteSync;
+    global $wpmus_newUserSync;
+    global $wpmus_setUserRoleSync;
+
+    echo '<div class="wrap">
+    <h3>Network Configuration</h3>
+    <p>These settings let you customize the sync behavior.</p>
+    <form method="post" action="edit.php?action=wpmusSaveGlobalConfig">';
+        wp_nonce_field( 'wpmus-validate' );
+        echo '
+        <table class="form-table">
+            <tr>
+                <th scope="row">New Site Automatic Sync</th>
+                <td>
+                    <label><input name="wpmus_newSiteSync" type="checkbox" value="yes" ' . checked('yes', $wpmus_newSiteSync, false ) . '> Sync new site with all users</label>
+                    <p class="description">When a new site is created in the network, all users in the database will be added to this new site with default site role. If no default role is configured, "subscriber" role will be added.</p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">New User Automatic Sync</th>
+                <td>
+                    <label><input name="wpmus_newUserSync" type="checkbox" value="yes" ' . checked('yes', $wpmus_newUserSync, false ) . '> Sync new users with all sites</label>
+                    <p class="description">When a new user is created in the network, will be added to all sites in the database with each default site role. If no default role is configured, "subscriber" role will be added.</p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">Set User Role Automatic Sync</th>
+                <td>
+                    <label><input name="wpmus_setUserRoleSync" type="checkbox" value="yes" ' . checked('yes', $wpmus_setUserRoleSync, false ) . '> Sync new user roles to all sites</label>
+                    <p class="description">When an user role change is detected in any site (for example change an user to administrator of an specific site) this change will be replicated to all other sites (in the other sites will be administrator, too).</p>
+                </td>
+            </tr>
+        </table>';
+
+        submit_button();
+    echo '</form></div>';
+
+}

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,0 +1,54 @@
+=== Multisite User Sync ===
+Contributors: shamim51
+Tags: multisite,multisite user sync,user sync,sync,multisite user
+Requires at least: 4.4
+Tested up to: 4.9.8
+Requires PHP: 5.4
+Stable tag: 1.2
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Multisite User Sync will automatically synchronize users to all sites in multisite. Roles of users will be same on everysite.
+
+== Description ==
+
+Multisite User Sync will automatically synchronize users to all sites in multisite. Roles of users will be same on every site. If Role change in one site it will also synchronize to all site. If new user/site created it will also add to all site/users.
+
+In one of my website it was needed to separate them fully for every product. So i use multisite. But it also needed to use same users (including role) for every site. So i write one plugin. I have searched for this type of plugins and i found none. So i upload it to wordpress plugin directory if somebody need it. This plugin works out of the box, No settings required.
+
+
+== Installation ==
+1. Upload "multisite-user-sync" to the "/wp-content/plugins/" directory.
+1. Activate the plugin through the "Plugins" menu in WordPress.
+1. **Network Activate** this plugin if you want to sync all users in all sites.
+1. Activate in Individual sites if you want to sync only users created/Change in those sites.
+
+
+== Frequently Asked Questions ==
+= How This Plugin Works? =
+When activate this plugin it will add all users from current site to all sites. So that all users are in sync between subsites. Role will be same as current site role in all sites.
+When a new site is created it will add all users to new sites in same role.
+When a new user is created it loop through all sites and add this new user to all sites in same role. When a role is changed in one site it loop through all sites and change this user role to all sites.
+
+= Can i sync users created/changed in particular site(s)? =
+Yes. In that case do not activate this in Network Activate. Just activate this plugin for that particular site(s).
+
+== Screenshots ==
+
+1. Activate
+
+== Changelog ==
+
+= 1.2 =
+
+* This plugin is redesigned. Logic changed. Bug fixed where it was issue when sync users.
+
+= 1.1 =
+
+* Initial release.
+
+== Upgrade Notice ==
+
+= 1.1 =
+
+* Initial release.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -16,9 +16,9 @@ Welcome to the best free user synchronization solution for WordPress Multisite.
 
 == Installation ==
 
-The normal plugin install process applies, that is search for 'Hola Simpsons' from your plugin screen or via the manual method:
+The normal plugin install process applies, that is search for 'WPM User Sync' from your plugin screen or via the manual method:
 
-1. Upload the 'Hola Simpsons' folder into your '/wp-content/plugins/' directory.
+1. Upload the 'WPM User Sync' folder into your '/wp-content/plugins/' directory.
 1. Activate the plugin through the 'Plugins' menu in WordPress.
 
 That's it! 'WPM User Sync' will appear in your dashboard at Network & Site level

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,54 +1,101 @@
-=== Multisite User Sync ===
-Contributors: shamim51
-Tags: multisite,multisite user sync,user sync,sync,multisite user
-Requires at least: 4.4
-Tested up to: 4.9.8
-Requires PHP: 5.4
-Stable tag: 1.2
+=== WPM User Sync ===
+Contributors: pablodiloreto
+Donate link: https://pablodiloreto.com/
+Tags: multisite, wpm user sync, user sync, sync, multisite user
+Requires at least: 5.1.2
+Tested up to: 5.4
+Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Multisite User Sync will automatically synchronize users to all sites in multisite. Roles of users will be same on everysite.
+Welcome to the best free user synchronization solution for WordPress Multisite.
 
 == Description ==
 
-Multisite User Sync will automatically synchronize users to all sites in multisite. Roles of users will be same on every site. If Role change in one site it will also synchronize to all site. If new user/site created it will also add to all site/users.
-
-In one of my website it was needed to separate them fully for every product. So i use multisite. But it also needed to use same users (including role) for every site. So i write one plugin. I have searched for this type of plugins and i found none. So i upload it to wordpress plugin directory if somebody need it. This plugin works out of the box, No settings required.
-
+'WPM User Sync' (which actually means "WordPress Multi-Site User Synchronization") is a plugin that allow you to configure & automate users sync between wordpress sites when you are using a multi-site setup. You will find options at network & sites level, to take aboslute control with what happen when: a new user is created, a new site is created, and when we change a role for an existing user. Enjoy! 
 
 == Installation ==
-1. Upload "multisite-user-sync" to the "/wp-content/plugins/" directory.
-1. Activate the plugin through the "Plugins" menu in WordPress.
-1. **Network Activate** this plugin if you want to sync all users in all sites.
-1. Activate in Individual sites if you want to sync only users created/Change in those sites.
 
+The normal plugin install process applies, that is search for 'Hola Simpsons' from your plugin screen or via the manual method:
+
+1. Upload the 'Hola Simpsons' folder into your '/wp-content/plugins/' directory.
+1. Activate the plugin through the 'Plugins' menu in WordPress.
+
+That's it! 'WPM User Sync' will appear in your dashboard at Network & Site level
 
 == Frequently Asked Questions ==
-= How This Plugin Works? =
-When activate this plugin it will add all users from current site to all sites. So that all users are in sync between subsites. Role will be same as current site role in all sites.
-When a new site is created it will add all users to new sites in same role.
-When a new user is created it loop through all sites and add this new user to all sites in same role. When a role is changed in one site it loop through all sites and change this user role to all sites.
 
-= Can i sync users created/changed in particular site(s)? =
-Yes. In that case do not activate this in Network Activate. Just activate this plugin for that particular site(s).
+= What exactly does this plugin do? =
+
+WPM User Sync is a plugin that enable the user synchronization in your Wordpress Multisite, that is a type of WordPress installation that allows you to create and manage a network of multiple websites from a single WordPress dashboard. Key concepts:
+
+- WPM User sync is a plugin, not a core feature of WordPress. It was built by external developers to WordPress. However, it goes through a detailed testing process to ensure smooth operation as it interacts with core aspects of the CMS.
+- In out-of-the-box WordPress multisite setup, when you create a new user, it never sync to other sites in your network. Also, when you create a new site in your network, no users are synced to this new site. This means that you must manually register or associate users to your site, or your new site with your users. This is a tedious and manual process.
+- This plugin bring you the possibility tu automate all this scenarios: a) when you create a new user, this user can be synced to all existing sites in your network; b) when you create a new site, all users can be automatic synced to it; c) when we change an user role in one site, you can configure to replicate this change to all sites in your network; d) if you do not want automation, with this plugin you can do all previous things in manual mode :-).
+- Last but not least, when we talk about 'user synchronization', we never duplicate user data. The user is only one, and the same identity is the one that is added to the sites in a reference model. If you are using "SUBDOMAIN_INSTALL" option (that is, each site on your network will be a subdomain) and you want "single-sign on experience", you should configure some cookies aspects in your WP-CONFIG. Check plugin's website help for more information.
+
+= What is a trigger? Which ones exist here? =
+
+In WPM User Sync you will can configure some triggers to automate user sync. A trigger is procedural code that is automatically executed in response to certain events, and in the particular case of WPM User Sync & WordPress, to one of the following events:
+
+- New user creation: when an user register in your site, or an admin create a new one.
+- New site creation: when an admin or authorized user create a new site in your network.
+- User role edited in one site: when you edit a user role in one of your network sites.
+
+Its very important to remember that you can configure all these 3 triggers from network level options.
+
+= What kind of options do I have at the network level? =
+
+At network level you can configure the 3 triggers that we descripted in the past:
+
+- New Site Automatic Sync: When a new site is created in the network, all users in the database will be added to this new site with default site role. If no default role is configured, "subscriber" role will be added.
+- New User Automatic Sync: When a new user is created in the network, will be added to all sites in the database with each default site role. If no default role is configured, "subscriber" role will be added.
+- Set User Role Automatic Sync: When an user role change is detected in any site (for example change an user to administrator of an specific site) this change will be replicated to all other sites (in the other sites will be administrator, too).
+
+Also, you can execute the following actions:
+
+- Sync from scratch: Sync all sites with all users. Each site will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+- Sync specific site: All selected sites will receive all users with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+
+= What can configure an administrator at site level? =
+
+At site level you can not configure any option. But you can execute the following action:
+
+- Sync from scratch: Add all network users in your site with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.
+
+= Can I avoid automatic actions and only act with manual actions? =
+
+Yes! You can. Disable all triggers at network level & you will allow to execute only manual actions.
+
+= Does this plugin host information in the local WordPress database? =
+
+Yes. This plugin host information in "sitemeta" table to remember network sync options.
+
+= Does this plugin connect to any external web service? =
+
+Nope.
+
+= I love it, how can I show my appreciation? =
+
+If you have been impressed with this plugin and would like to somehow show some appreciation, rather than send a donation my way, please donate to your charity of choice. I will never ask for any form of reward or compensation. Helping others achieve their goals is satisfying for me :)
 
 == Screenshots ==
+ 
+1. Plugin Home for Network Admins.
+2. Network level Options for WPM User Sync.
+3. Network level Actions for WPM User Sync.
+4. Plugin Home for Site Admins.
+5. Site level Actions for WPM User Sync.
 
-1. Activate
-
-== Changelog ==
-
-= 1.2 =
-
-* This plugin is redesigned. Logic changed. Bug fixed where it was issue when sync users.
-
-= 1.1 =
-
-* Initial release.
 
 == Upgrade Notice ==
 
-= 1.1 =
+= 1.0 =
+First release. Check help for all features.
 
-* Initial release.
+== Changelog ==
+
+= 1.0 (2020-04-05) =
+* Initial source code.
+* Bump tested WordPress version to 5.4
+* Check help for all features.

--- a/src/site-admin/wpmus-site-home.php
+++ b/src/site-admin/wpmus-site-home.php
@@ -1,0 +1,117 @@
+<?php
+
+function wpmus_site_home_content() {
+    
+    global $sd_active_tab;
+
+    if (isset($_GET['tab'])) {
+        $sd_active_tab = sanitize_text_field($_GET['tab']);
+        
+    }else{
+        $sd_active_tab = 'welcome';
+
+    }
+    
+    ?>
+
+    <h2 class="nav-tab-wrapper">
+    <?php
+        do_action( 'wpmus_site_home_tabs' );
+    ?>
+    </h2>
+    <?php
+        do_action( 'wpmus_site_home_contents' );
+    
+}
+
+function wpmus_site_home_welcome_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'welcome' || '' ? 'nav-tab-active' : ''; ?>" href="<?php echo admin_url( 'admin.php?page=wpmus-sitehome&tab=welcome' ); ?>"><?php _e( 'Welcome', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_site_home_concepts_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'concepts' ? 'nav-tab-active' : ''; ?>" href="<?php echo admin_url( 'admin.php?page=wpmus-sitehome&tab=concepts' ); ?>"><?php _e( 'Concepts', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_site_home_about_tab(){
+    global $sd_active_tab; ?>
+    <a class="nav-tab <?php echo $sd_active_tab == 'about' ? 'nav-tab-active' : ''; ?>" href="<?php echo admin_url( 'admin.php?page=wpmus-sitehome&tab=about' ); ?>"><?php _e( 'About', 'sd' ); ?> </a>
+    <?php
+}
+
+function wpmus_site_home_welcome_content() {
+    global $sd_active_tab;
+    if ( '' || 'welcome' != $sd_active_tab )
+        return;
+    ?>
+
+    <h3><?php _e( 'Welcome to Site "WPM User Sync" Plugin', 'sd' ); ?></h3>
+    <p>Thank you for choosing WPM User Sync (which actually means "WordPress Multi-Site User Synchronization").</p>
+    <p>If you are new using this plugin, we recommend you to check the basic synchronization concepts. If this is the first time you use the plugin, you can also do your first full sync.</p>
+
+    <a href="<?php echo admin_url( 'admin.php?page=wpmus-sitehome&tab=concepts' ); ?>" class="cuadrado">1. Review basic concepts</a>
+    <a href="<?php echo admin_url( 'admin.php?page=wpmus-sitesyncactions' ); ?>" class="cuadrado">2. Complete the initial Users Sync</a>
+    <a href="<?php echo admin_url( 'admin.php?page=wpmus-sitehome&tab=about' ); ?>" class="cuadrado">3. Meet the Authors & Support Us</a>
+
+    <p>Do you want online help? Check our <a href="https://pablodiloreto.com/wpm-user-sync/">site</a>.</p>
+
+    <?php
+}
+
+function wpmus_site_home_concepts_content() {
+    global $sd_active_tab;
+    if ( 'concepts' != $sd_active_tab )
+        return;
+    ?>
+
+    <h3><?php _e( 'Site User Sync Concepts', 'sd' ); ?></h3>
+    <p>WPM User Sync has some simple but important concepts. Knowning all them will help you to get a better experience with the tool.</p>
+
+    <h4>What exactly does this plugin do?</h4>
+    <p>WPM User Sync is a plugin that enable the user synchronization in your Wordpress Multisite, that is a type of WordPress installation that allows you to create and manage a network of multiple websites from a single WordPress dashboard.</p>
+    <p>Key concepts:</p>
+    <ul>
+        <li>- WPM User sync is a plugin, not a core feature of WordPress. It was built by external developers to WordPress. However, it goes through a detailed testing process to ensure smooth operation as it interacts with core aspects of the CMS.</li>
+        <li>- In out-of-the-box WordPress multisite setup, when you create a new user, it never sync to other sites in your network. Also, when you create a new site in your network, no users are synced to this new site. This means that you must manually register or associate users to your site, or your new site with your users. This is a tedious and manual process.</li>
+        <li>- This plugin bring you the possibility tu automate all this scenarios: a) when you create a new user, this user can be synced to all existing sites in your network; b) when you create a new site, all users can be automatic synced to it; c) when we change an user role in one site, you can configure to replicate this change to all sites in your network; d) if you do not want automation, with this plugin you can do all previous things in manual mode :-).</li>
+        <li>- Last but not least, when we talk about 'user synchronization', we never duplicate user data. The user is only one, and the same identity is the one that is added to the sites in a reference model. If you are using "SUBDOMAIN_INSTALL" option (that is, each site on your network will be a subdomain) and you want "single-sign on experience", you should configure some cookies aspects in your WP-CONFIG. Check plugin's website help for more information.</li>
+    </ul>
+
+    <h4>What is a trigger? Which ones exist here?</h4>
+    <p>In WPM User Sync you will can configure some triggers to automate user sync. A trigger is procedural code that is automatically executed in response to certain events, and in the particular case of WPM User Sync & WordPress, to one of the following events:</p>
+    <ul>
+        <li>- <strong>New user creation</strong>: when an user register in your site, or an admin create a new one.</li>
+        <li>- <strong>New site creation</strong>: when an admin or authorized user create a new site in your network.</li>
+        <li>- <strong>User role edited in one site</strong>: when you edit a user role in one of your network sites.</li>
+    </ul>
+    <p>Your Network Admin can configure all these 3 triggers from network level options.</p>
+
+    <h4>What can configure an administrator at site level?</h4>
+    <p>At site level you can not configure any option. All options must be configured at Network Level. But you, as Site Admin, can execute the following action:</p>
+    <ul>
+        <li>- <strong>Sync from scratch</strong>: Add all network users in your site with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</li>
+    </ul>
+
+    <h4>Can I avoid automatic actions and only act with manual actions?</h4>
+    <p>Yes! But it must be configured by a Network Level Admin.</p>
+    <?php
+}
+
+function wpmus_site_home_about_content() {
+global $sd_active_tab;
+if ( 'about' != $sd_active_tab )
+    return;
+?>
+
+<h3><?php _e( 'About', 'sd' ); ?></h3>
+<p>This plugin was developer by <strong>Pablo Ariel Di Loreto</strong>:</p>
+<ul>
+    <li>- <a href="https://www.linkedin.com/in/pablodiloreto/" target="_blank">LinkedIn Contact</a>.</li>
+    <li>- <a href="https://pablodiloreto.com/" target="_blank">Personal Blog</a>.</li>
+    <li>- <a href="https://pablodiloreto.com/wpm-user-sync/" target="_blank">Plugin Homepage</a>.</li>
+</ul>
+<?php
+}

--- a/src/site-admin/wpmus-site-sections.php
+++ b/src/site-admin/wpmus-site-sections.php
@@ -1,0 +1,43 @@
+<?php
+
+
+// class wpmus {
+
+	function wpmus_sitemenu_items() {
+ 
+		add_menu_page(
+			'WPM User Sync', // page_title
+			'WPM User Sync', // menu_title
+			'manage_options', // capability
+			'wpmus-sitehome', // menu_slug
+			'wpmus_sitehome', // Callback function which displays the page
+			'dashicons-admin-generic', // Icon
+			100 // Position of the menu item in the menu.
+		);
+
+		add_submenu_page(
+			'wpmus-sitehome', // Parent element
+			'Site Sync Actions', // Text in browser title bar
+			'Site Sync Actions', // Text to be displayed in the menu.
+			'manage_options', // Capability
+			'wpmus-sitesyncactions', // Page slug, will be displayed in URL
+			'wpmus_sitesyncactions' // Callback function which displays the page
+		);
+ 
+	}
+
+	function wpmus_sitehome() {
+    
+		echo wpmus_generic_header();
+		echo wpmus_site_home_content();
+	  
+	}
+
+	function wpmus_sitesyncactions() {
+	
+		echo wpmus_generic_header();
+		echo wpmus_site_syncactions_options();
+
+	}
+
+    

--- a/src/site-admin/wpmus-site-syncactions.php
+++ b/src/site-admin/wpmus-site-syncactions.php
@@ -1,0 +1,28 @@
+<?php
+
+function wpmus_site_syncactions_options() {
+
+    echo '<div class="wrap">
+    <h3>Site Sync Actions</h3>
+    <p>These actions let you sync all network users in your site.</p>';
+        wp_nonce_field( 'wpmus-validate' );
+        echo '
+        <table class="form-table">
+            <tr>
+                <th scope="row">Sync from scratch</th>
+                <td>
+                    <form method="post" action="edit.php?action=wpmusSyncSiteSiteFromScratch">';
+                    wp_nonce_field( 'wpmus-validate' );
+                    echo '
+                        <input id="test-settings" type="submit" value="Sync from scratch" class="button" >
+                        <input id="blogid" type="hidden" value=';
+                        echo get_current_blog_id();
+                        echo '>
+                        <input id="site" type="hidden" value="yes">
+                    </form>
+                    <p class="description">Add all network users in your site with default site role. If no default role is configured, "subscriber" role will be added. Existing users will have not changes.</p>
+                </td>
+            </tr>
+        </table>';
+
+}

--- a/src/wpm-user-sync.php
+++ b/src/wpm-user-sync.php
@@ -1,0 +1,62 @@
+<?php
+/*
+Plugin Name: WPM User Sync
+Plugin URI: https://pablodiloreto.work/wpm-user-sync/
+Description: xxxxx.
+Author: Pablo Ariel Di Loreto
+Version: 1.0
+Requires at least: 5.3.2
+Tested up to: 5.3.2
+Author URI: https://pablodiloreto.work
+Text Domain: wpm-user-sync
+License: GPLv2 or later
+*/
+
+
+require_once (dirname(__FILE__).'/core/wpmus-variables.php');
+require_once (dirname(__FILE__).'/core/wpmus-functions.php');
+
+require_once (dirname(__FILE__).'/network-admin/wpmus-network-sections.php');
+require_once (dirname(__FILE__).'/network-admin/wpmus-network-common.php');
+require_once (dirname(__FILE__).'/network-admin/wpmus-network-home.php');
+require_once (dirname(__FILE__).'/network-admin/wpmus-network-syncoptions.php');
+require_once (dirname(__FILE__).'/network-admin/wpmus-network-syncactions.php');
+
+require_once (dirname(__FILE__).'/site-admin/wpmus-site-sections.php');
+require_once (dirname(__FILE__).'/site-admin/wpmus-site-home.php');
+require_once (dirname(__FILE__).'/site-admin/wpmus-site-syncactions.php');
+
+register_activation_hook( __FILE__, 'wpmus_plugin_activate' );
+
+add_action('init', 'wpmus_init');
+
+add_action( 'admin_init', 'wpmus_check_requirements' );
+add_action( 'network_admin_menu', 'wpmus_networkmenu_items' );
+add_action( 'admin_menu', 'wpmus_sitemenu_items' );
+
+
+add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_welcome_tab', 1 );
+add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_concepts_tab', 2 );
+add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_about_tab', 3 );
+add_action( 'wpmus_network_home_contents', 'wpmus_network_home_welcome_content' );
+add_action( 'wpmus_network_home_contents', 'wpmus_network_home_concepts_content' );
+add_action( 'wpmus_network_home_contents', 'wpmus_network_home_about_content' );
+
+add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_welcome_tab', 1 );
+add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_concepts_tab', 2 );
+add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_about_tab', 3 );
+add_action( 'wpmus_site_home_contents', 'wpmus_site_home_welcome_content' );
+add_action( 'wpmus_site_home_contents', 'wpmus_site_home_concepts_content' );
+add_action( 'wpmus_site_home_contents', 'wpmus_site_home_about_content' );
+
+add_action( 'wpmu_new_blog', 'wpmus_sync_newsite' );
+add_action( 'wpmu_new_user', 'wpmus_sync_newuser' );
+add_action( 'set_user_role', 'wpmus_sync_newrole', 10, 2 );
+
+add_action( 'network_admin_edit_wpmusSaveGlobalConfig', 'wpmus_save_GlobalConfig' );
+add_action( 'network_admin_edit_wpmusSyncNetworkFromScratch', 'wpmus_sync_NetworkFromScratch' );
+add_action( 'admin_action_wpmusSyncNetworkSiteFromScratch', 'wpmus_sync_NetworkSiteFromScratch' );
+add_action( 'admin_action_wpmusSyncSiteSiteFromScratch', 'wpmus_sync_SiteSiteFromScratch' );
+
+add_action( 'network_admin_notices', 'wpmus_notice_updated' );
+add_action( 'admin_notices', 'wpmus_notice_updated' );

--- a/src/wpm-user-sync.php
+++ b/src/wpm-user-sync.php
@@ -1,13 +1,13 @@
 <?php
 /*
 Plugin Name: WPM User Sync
-Plugin URI: https://pablodiloreto.work/wpm-user-sync/
-Description: xxxxx.
+Plugin URI: https://pablodiloreto.com/wpm-user-sync/
+Description: WPM User Sync is THE plugin that allow you to configure & automate users sync between wordpress sites when you are using a multi-site setup.
 Author: Pablo Ariel Di Loreto
 Version: 1.0
-Requires at least: 5.3.2
-Tested up to: 5.3.2
-Author URI: https://pablodiloreto.work
+Requires at least: 5.1.2
+Tested up to: 5.4
+Author URI: https://pablodiloreto.com/wpm-user-sync/
 Text Domain: wpm-user-sync
 License: GPLv2 or later
 */


### PR DESCRIPTION
### Initial Code

Hello! 'WPM User Sync' (which actually means "WordPress Multi-Site User Synchronization") is a plugin that allow you to configure & automate users sync between wordpress sites when you are using a multi-site setup. You will find options at network & sites level, to take aboslute control with what happen when: a new user is created, a new site is created, and when we change a role for an existing user.

### Features

The initial features are:

- Network Options: home, options & actions.
- Site Options: home & actions.
- 'Sync new site with all users' option at network level.
- 'Sync new users with all sites' option at network level.
- 'Sync new user roles to all sites' option at network level.
- 'Sync from scratch' at network & site level.
- 'Sync specific site' at network level.