### PR TITLE
Bug fixes 200412 added to dev

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://pablodiloreto.com/
 Tags: multisite, wpm user sync, user sync, sync, multisite user
 Requires at least: 5.1.2
 Tested up to: 5.4
-Stable tag: 1.0
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,10 +90,17 @@ If you have been impressed with this plugin and would like to somehow show some 
 
 == Upgrade Notice ==
 
+= 1.1 =
+Bug fixes.
+
 = 1.0 =
 First release. Check help for all features.
 
 == Changelog ==
+
+= 1.1 (2020-04-11) =
+* Bug fixed: user sync when end-user register in the network.
+* Performance improved adding some conditional during triggers.
 
 = 1.0 (2020-04-05) =
 * Initial source code.

--- a/src/wpm-user-sync.php
+++ b/src/wpm-user-sync.php
@@ -56,7 +56,7 @@ add_action( 'wpmus_site_home_contents', 'wpmus_site_home_welcome_content' );
 add_action( 'wpmus_site_home_contents', 'wpmus_site_home_concepts_content' );
 add_action( 'wpmus_site_home_contents', 'wpmus_site_home_about_content' );
 
-// Triggers
+// Triggers fro actions
 if ($wpmus_newSiteSync == 'yes') {
     add_action( 'wpmu_new_blog', 'wpmus_sync_newsite' );
 }

--- a/src/wpm-user-sync.php
+++ b/src/wpm-user-sync.php
@@ -4,7 +4,7 @@ Plugin Name: WPM User Sync
 Plugin URI: https://pablodiloreto.com/wpm-user-sync/
 Description: WPM User Sync is THE plugin that allow you to configure & automate users sync between wordpress sites when you are using a multi-site setup.
 Author: Pablo Ariel Di Loreto
-Version: 1.0
+Version: 1.1
 Requires at least: 5.1.2
 Tested up to: 5.4
 Author URI: https://pablodiloreto.com/wpm-user-sync/
@@ -12,29 +12,35 @@ Text Domain: wpm-user-sync
 License: GPLv2 or later
 */
 
-
+// Load required core plugin files
 require_once (dirname(__FILE__).'/core/wpmus-variables.php');
 require_once (dirname(__FILE__).'/core/wpmus-functions.php');
 
+// Load required network-admin files
 require_once (dirname(__FILE__).'/network-admin/wpmus-network-sections.php');
 require_once (dirname(__FILE__).'/network-admin/wpmus-network-common.php');
 require_once (dirname(__FILE__).'/network-admin/wpmus-network-home.php');
 require_once (dirname(__FILE__).'/network-admin/wpmus-network-syncoptions.php');
 require_once (dirname(__FILE__).'/network-admin/wpmus-network-syncactions.php');
 
+// Load required site-admin files
 require_once (dirname(__FILE__).'/site-admin/wpmus-site-sections.php');
 require_once (dirname(__FILE__).'/site-admin/wpmus-site-home.php');
 require_once (dirname(__FILE__).'/site-admin/wpmus-site-syncactions.php');
 
+global $wpmus_newUserSync;
+global $wpmus_newSiteSync;
+global $wpmus_setUserRoleSync;
+
+
+// Administrative triggers
 register_activation_hook( __FILE__, 'wpmus_plugin_activate' );
-
-add_action('init', 'wpmus_init');
-
-add_action( 'admin_init', 'wpmus_check_requirements' );
+add_action( 'init', 'wpmus_init' );
 add_action( 'network_admin_menu', 'wpmus_networkmenu_items' );
 add_action( 'admin_menu', 'wpmus_sitemenu_items' );
+add_action( 'admin_init', 'wpmus_check_requirements' );
 
-
+// Load tabs feature at network-level for home
 add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_welcome_tab', 1 );
 add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_concepts_tab', 2 );
 add_action( 'wpmus_network_home_tabs', 'wpmus_network_home_about_tab', 3 );
@@ -42,6 +48,7 @@ add_action( 'wpmus_network_home_contents', 'wpmus_network_home_welcome_content' 
 add_action( 'wpmus_network_home_contents', 'wpmus_network_home_concepts_content' );
 add_action( 'wpmus_network_home_contents', 'wpmus_network_home_about_content' );
 
+// Load tabs feature at site-level for home
 add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_welcome_tab', 1 );
 add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_concepts_tab', 2 );
 add_action( 'wpmus_site_home_tabs', 'wpmus_site_home_about_tab', 3 );
@@ -49,14 +56,25 @@ add_action( 'wpmus_site_home_contents', 'wpmus_site_home_welcome_content' );
 add_action( 'wpmus_site_home_contents', 'wpmus_site_home_concepts_content' );
 add_action( 'wpmus_site_home_contents', 'wpmus_site_home_about_content' );
 
-add_action( 'wpmu_new_blog', 'wpmus_sync_newsite' );
-add_action( 'wpmu_new_user', 'wpmus_sync_newuser' );
-add_action( 'set_user_role', 'wpmus_sync_newrole', 10, 2 );
+// Triggers
+if ($wpmus_newSiteSync == 'yes') {
+    add_action( 'wpmu_new_blog', 'wpmus_sync_newsite' );
+}
+if ($wpmus_newUserSync == 'yes') {
+    add_action( 'wpmu_new_user', 'wpmus_sync_newuser' );
+    add_action( 'wp_login', 'wpmus_maybesync_newuser', 10, 1 );
+    add_action( 'social_connect_login', 'wpmus_maybesync_newuser', 10, 1 );
+}
+if ($wpmus_setUserRoleSync == 'yes') {
+    add_action( 'set_user_role', 'wpmus_sync_newrole', 10, 2 );
+}
 
+// Save configuration actions
 add_action( 'network_admin_edit_wpmusSaveGlobalConfig', 'wpmus_save_GlobalConfig' );
 add_action( 'network_admin_edit_wpmusSyncNetworkFromScratch', 'wpmus_sync_NetworkFromScratch' );
 add_action( 'admin_action_wpmusSyncNetworkSiteFromScratch', 'wpmus_sync_NetworkSiteFromScratch' );
 add_action( 'admin_action_wpmusSyncSiteSiteFromScratch', 'wpmus_sync_SiteSiteFromScratch' );
 
+// Admin notices
 add_action( 'network_admin_notices', 'wpmus_notice_updated' );
 add_action( 'admin_notices', 'wpmus_notice_updated' );


### PR DESCRIPTION
### BUG fixed #6 

When a user is created from front-end, in several cases the trigger "New User Automated Sync" is not working. This reason is because 'wpmu_activate_user', 'wpmu_new_user' & 'wpmu_activate_blog' hook can only be hooked if the plugin is in the mu-plugins folder, which is a PITA.

I added a new hook using 'wp_login' & 'social_connect_login' to a new function called wpmus_maybesync_newuser, that check if the option "New User Automatic Sync" is true, and if so it ensure that the logged in user is in all sites.